### PR TITLE
File:request.go, add RequestBodyContext struct for request body parser

### DIFF
--- a/request.go
+++ b/request.go
@@ -1,6 +1,9 @@
 package validator
 
 import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"time"
 )
@@ -31,4 +34,109 @@ func (c *RequestContext) Value(key interface{}) interface{} {
 		return req.PostFormValue(key.(string))
 	}
 	return nil
+}
+
+// Request Body parser
+
+/*
+RequestBodyContext implement the context interface, and provide some parse functions.
+
+this main to parse the request body, and for body stream can be open twice. it will not
+break the stream of request stream, in other words, it copy the request stream for parse.
+
+For use:
+vdr := validator.SetContext(NewRequestBodyContext( { request } ))
+res := vdr.CheckStruct( { your struct } )
+*/
+type RequestBodyContext struct {
+	r         *http.Request
+	bodyBytes [] byte
+	readFunc  func(value []byte, targetKey interface{}) interface{}
+}
+
+/*
+NewRequestBodyContext will create new RequestBodyContext, it only set http.Request.
+*/
+func NewRequestBodyContext(r *http.Request) *RequestBodyContext {
+	return &RequestBodyContext{r: r}
+}
+
+func (c *RequestBodyContext) Deadline() (deadline time.Time, ok bool) { return }
+func (c *RequestBodyContext) Done() <-chan struct{}                   { return nil }
+func (c *RequestBodyContext) Err() error                              { return nil }
+func (c *RequestBodyContext) Value(key interface{}) interface{} {
+	// check parser func, if nil use default json parser func
+	if c.readFunc == nil {
+		c.readFunc = c.DefaultJsonParserFunc
+	}
+	if c.bodyBytes == nil || len(c.bodyBytes) == 0 {
+		// get request body
+		c.bodyBytes, _ = ioutil.ReadAll(c.r.Body)
+		// close BufferReader to rewrite request body
+		c.r.Body.Close()
+		// rewrite request body
+		c.r.Body = ioutil.NopCloser(bytes.NewBuffer(c.bodyBytes))
+	}
+	return c.readFunc(c.bodyBytes, key)
+}
+
+/*
+SetReadFunc will set body parser func.
+
+For different body, it may has different parse actions. So open the door of body parse func.
+The parser func define:
+	func FuncName(value []byte, targetKey interface{}) interface{} {
+		func body...
+	}
+
+If doesn't invoke this func, RequestBodyContext will use default func :
+	func (c RequestBodyContext) DefaultJsonParserFunc(value [] byte, targetKey interface{}) interface{}
+
+And one kind of body only can use one kind of parser func. It means that you only write all operation of body's read and
+parser. Else some operation will has error.
+
+But some time, for different key may use different parse actions. It can write like this:
+	func Func1(value []byte, targetKey interface{}) interface{} {
+		func body...
+	}
+	func Func2(value []byte, targetKey interface{}) interface{} {
+		func body...
+	}
+	func FuncAll(value []byte, targetKey interface{}) interface{} {
+		if targetKey == "1"{
+			return Func1(value, targetKey)
+		}
+		if targetKey == "2"{
+			return Func2(value, targetKey)
+		}
+
+		func body...
+	}
+	======= set read func
+	vdr := validator.SetContext(NewRequestBodyContext( { request } ).SetReadFunc(FuncAll))
+	res := vdr.CheckStruct( { your struct } )
+*/
+func (c *RequestBodyContext) SetReadFunc(readFunc func(value []byte, targetKey interface{}) interface{}) *RequestBodyContext {
+	c.readFunc = readFunc
+	return c
+}
+
+/*
+DefaultJsonParserFunc will set parser json string. It is the RequestBodyContext default read func.
+Note: It only can parse only one floor json object. Such as { "a":"a"}, but can't parse : {"a":{"a":"a"}}.
+
+If happen some errors, it will return the empty string( is "", not nil).
+*/
+func (c RequestBodyContext) DefaultJsonParserFunc(value [] byte, targetKey interface{}) interface{} {
+	var data map[string]interface{}
+
+	// convert json string to map[string]interface
+	err := json.Unmarshal(value, &data)
+
+	// has error will return ""
+	if err != nil {
+		return ""
+	}
+
+	return data[targetKey.(string)]
 }


### PR DESCRIPTION
Add `RequestBodyContext` to parse request body in file : `request.go`.

It implement the `request` interface, and use like `RequestContext`.

```golang
vdr := validator.SetContext(NewRequestBodyContext( { request } ))
res := vdr.CheckStruct( { your struct } )
```

Different parsing functions can be specified for different parsing situations.
```golang
vdr := validator.SetContext(NewRequestBodyContext( { request } ).SetReadFunc( { your func } ))
res := vdr.CheckStruct( { your struct } )
```